### PR TITLE
Upd socket flag enum

### DIFF
--- a/Sources/Sockets/Core/Error.swift
+++ b/Sources/Sockets/Core/Error.swift
@@ -30,7 +30,6 @@ public enum ErrorReason {
     case writeFailed
     
     case unsupportedSocketAddressFamily(Int32)
-	case unsupportedSocketFlag(Int32)
     case concreteSocketAddressFamilyRequired
     
     case socketIsClosed
@@ -107,9 +106,7 @@ extension SocketsError: Debuggable {
             return "Socket is closed"
         case .generic(let s):
             return s
-		case .unsupportedSocketFlag:
-			return "Unsupported socket flag"
-		}
+        }
     }
 
     public var identifier: String {
@@ -160,9 +157,7 @@ extension SocketsError: Debuggable {
             return "socketIsClosed"
         case .generic:
             return "generic"
-		case .unsupportedSocketFlag:
-			return "unsupportedSocketFlag"
-		}
+        }
     }
 
     public var possibleCauses: [String] {

--- a/Sources/Sockets/Core/Error.swift
+++ b/Sources/Sockets/Core/Error.swift
@@ -30,6 +30,7 @@ public enum ErrorReason {
     case writeFailed
     
     case unsupportedSocketAddressFamily(Int32)
+	case unsupportedSocketFlag(Int32)
     case concreteSocketAddressFamilyRequired
     
     case socketIsClosed
@@ -106,7 +107,9 @@ extension SocketsError: Debuggable {
             return "Socket is closed"
         case .generic(let s):
             return s
-        }
+		case .unsupportedSocketFlag:
+			return "Unsupported socket flag"
+		}
     }
 
     public var identifier: String {
@@ -157,7 +160,9 @@ extension SocketsError: Debuggable {
             return "socketIsClosed"
         case .generic:
             return "generic"
-        }
+		case .unsupportedSocketFlag:
+			return "unsupportedSocketFlag"
+		}
     }
 
     public var possibleCauses: [String] {

--- a/Sources/Sockets/Core/Types.swift
+++ b/Sources/Sockets/Core/Types.swift
@@ -32,14 +32,14 @@ public enum AddressFamily {
 }
 
 public enum UDPSocketRecvSendFlags {
-	/// process out-of-band data
-	case msg_oob
-	/// peek at incoming message
-	case msg_peek
-	/// wait for full request or error
-	case msg_waitall
-	/// bypass routing, use direct interface
-	case msg_dontroute
+    /// process out-of-band data
+    case msg_oob
+    /// peek at incoming message
+    case msg_peek
+    /// wait for full request or error
+    case msg_waitall
+    /// bypass routing, use direct interface
+    case msg_dontroute
 }
 
 public typealias Port = UInt16
@@ -113,35 +113,35 @@ extension AddressFamily: CTypeInt32Convertible {
 }
 
 extension AddressFamily {
-	init(fromCType cType: Int32) throws {
-		switch cType {
-		case Int32(AF_INET): self = .inet
-		case Int32(AF_INET6): self = .inet6
-		case Int32(AF_UNSPEC): self = .unspecified
-		default: throw SocketsError(.unsupportedSocketAddressFamily(cType))
-		}
-	}
+    init(fromCType cType: Int32) throws {
+        switch cType {
+        case Int32(AF_INET): self = .inet
+        case Int32(AF_INET6): self = .inet6
+        case Int32(AF_UNSPEC): self = .unspecified
+        default: throw SocketsError(.unsupportedSocketAddressFamily(cType))
+        }
+    }
 }
 
 extension UDPSocketRecvSendFlags: CTypeInt32Convertible {
-	func toCType() -> Int32 {
-		switch self {
-		case .msg_oob: return Int32(MSG_OOB)
-		case .msg_peek: return Int32(MSG_PEEK)
-		case .msg_waitall: return Int32(MSG_WAITALL)
-		case .msg_dontroute: return Int32(MSG_DONTROUTE)
-		}
-	}
+    func toCType() -> Int32 {
+        switch self {
+        case .msg_oob: return Int32(MSG_OOB)
+        case .msg_peek: return Int32(MSG_PEEK)
+        case .msg_waitall: return Int32(MSG_WAITALL)
+        case .msg_dontroute: return Int32(MSG_DONTROUTE)
+        }
+    }
 }
 
 extension UDPSocketRecvSendFlags {
-	init(fromCType cType: Int32) throws {
-		switch cType {
-		case Int32(MSG_OOB): self = .msg_oob
-		case Int32(MSG_PEEK): self = .msg_peek
-		case Int32(MSG_WAITALL): self = .msg_waitall
-		case Int32(MSG_DONTROUTE): self = .msg_dontroute
-		default: throw SocketsError(.unsupportedSocketFlag(cType))
-		}
-	}
+    init(fromCType cType: Int32) throws {
+        switch cType {
+        case Int32(MSG_OOB): self = .msg_oob
+        case Int32(MSG_PEEK): self = .msg_peek
+        case Int32(MSG_WAITALL): self = .msg_waitall
+        case Int32(MSG_DONTROUTE): self = .msg_dontroute
+        default: throw SocketsError(.generic("unsupportedSocketAddressFamily"))
+        }
+    }
 }

--- a/Sources/Sockets/Core/Types.swift
+++ b/Sources/Sockets/Core/Types.swift
@@ -35,6 +35,7 @@ public enum flags {
 	case msg_oob
 	case msg_peek
 	case msg_waitall
+	case msg_dontroute
 }
 
 public typealias Port = UInt16
@@ -107,12 +108,24 @@ extension AddressFamily: CTypeInt32Convertible {
     }
 }
 
+extension AddressFamily {
+	init(fromCType cType: Int32) throws {
+		switch cType {
+		case Int32(AF_INET): self = .inet
+		case Int32(AF_INET6): self = .inet6
+		case Int32(AF_UNSPEC): self = .unspecified
+		default: throw SocketsError(.unsupportedSocketAddressFamily(cType))
+		}
+	}
+}
+
 extension flags: CTypeInt32Convertible {
 	func toCType() -> Int32 {
 		switch self {
 		case .msg_oob: return Int32(MSG_OOB)
 		case .msg_peek: return Int32(MSG_PEEK)
 		case .msg_waitall: return Int32(MSG_WAITALL)
+		case .msg_dontroute: return Int32(MSG_DONTROUTE)
 		}
 	}
 }
@@ -123,20 +136,8 @@ extension flags {
 		case Int32(MSG_OOB): self = .msg_oob
 		case Int32(MSG_PEEK): self = .msg_peek
 		case Int32(MSG_WAITALL): self = .msg_waitall
+		case Int32(MSG_DONTROUTE): self = .msg_dontroute
 		default: throw SocketsError(.unsupportedSocketFlag(cType))
 		}
 	}
 }
-
-extension AddressFamily {
-    init(fromCType cType: Int32) throws {
-        switch cType {
-        case Int32(AF_INET): self = .inet
-        case Int32(AF_INET6): self = .inet6
-        case Int32(AF_UNSPEC): self = .unspecified
-        default: throw SocketsError(.unsupportedSocketAddressFamily(cType))
-        }
-    }
-}
-
-

--- a/Sources/Sockets/Core/Types.swift
+++ b/Sources/Sockets/Core/Types.swift
@@ -31,10 +31,14 @@ public enum AddressFamily {
     }
 }
 
-public enum flags {
+public enum UDPSocketRecvSendFlags {
+	/// process out-of-band data
 	case msg_oob
+	/// peek at incoming message
 	case msg_peek
+	/// wait for full request or error
 	case msg_waitall
+	/// bypass routing, use direct interface
 	case msg_dontroute
 }
 
@@ -119,7 +123,7 @@ extension AddressFamily {
 	}
 }
 
-extension flags: CTypeInt32Convertible {
+extension UDPSocketRecvSendFlags: CTypeInt32Convertible {
 	func toCType() -> Int32 {
 		switch self {
 		case .msg_oob: return Int32(MSG_OOB)
@@ -130,7 +134,7 @@ extension flags: CTypeInt32Convertible {
 	}
 }
 
-extension flags {
+extension UDPSocketRecvSendFlags {
 	init(fromCType cType: Int32) throws {
 		switch cType {
 		case Int32(MSG_OOB): self = .msg_oob

--- a/Sources/Sockets/Core/Types.swift
+++ b/Sources/Sockets/Core/Types.swift
@@ -31,6 +31,12 @@ public enum AddressFamily {
     }
 }
 
+public enum flags {
+	case msg_oob
+	case msg_peek
+	case msg_waitall
+}
+
 public typealias Port = UInt16
 
 //Extensions
@@ -101,8 +107,28 @@ extension AddressFamily: CTypeInt32Convertible {
     }
 }
 
+extension flags: CTypeInt32Convertible {
+	func toCType() -> Int32 {
+		switch self {
+		case .msg_oob: return Int32(MSG_OOB)
+		case .msg_peek: return Int32(MSG_PEEK)
+		case .msg_waitall: return Int32(MSG_WAITALL)
+		}
+	}
+}
+
+extension flags {
+	init(fromCType cType: Int32) throws {
+		switch cType {
+		case Int32(MSG_OOB): self = .msg_oob
+		case Int32(MSG_PEEK): self = .msg_peek
+		case Int32(MSG_WAITALL): self = .msg_waitall
+		default: throw SocketsError(.unsupportedSocketFlag(cType))
+		}
+	}
+}
+
 extension AddressFamily {
-    
     init(fromCType cType: Int32) throws {
         switch cType {
         case Int32(AF_INET): self = .inet

--- a/Sources/Sockets/UDP/UDPSocket.swift
+++ b/Sources/Sockets/UDP/UDPSocket.swift
@@ -31,8 +31,8 @@ public class UDPInternetSocket: InternetSocket {
 	public func recvfrom(maxBytes: Int = BufferCapacity, flags flagArray: [UDPSocketRecvSendFlags] = []) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let data = Buffer(capacity: maxBytes)
-		var flags: Int32 = 0
-		flagArray.forEach { flags |= $0.toCType() }
+        var flags: Int32 = 0
+        flagArray.forEach { flags |= $0.toCType() }
 
         var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
         let addr = UnsafeMutablePointer<sockaddr_storage>.allocate(capacity: 1)
@@ -61,8 +61,8 @@ public class UDPInternetSocket: InternetSocket {
 	public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil, flags flagArray: [UDPSocketRecvSendFlags] = []) throws {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let len = data.count
-		var flags: Int32 = 0
-		flagArray.forEach { flags |= $0.toCType() }
+        var flags: Int32 = 0
+        flagArray.forEach { flags |= $0.toCType() }
         let destination = address ?? self.address
 
         let sentLen = libc.sendto(

--- a/Sources/Sockets/UDP/UDPSocket.swift
+++ b/Sources/Sockets/UDP/UDPSocket.swift
@@ -28,7 +28,7 @@ public class UDPInternetSocket: InternetSocket {
         try? self.close()
     }
 
-	public func recvfrom(maxBytes: Int = BufferCapacity, flags flagArray: [flags] = []) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
+	public func recvfrom(maxBytes: Int = BufferCapacity, flags flagArray: [UDPSocketRecvSendFlags] = []) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let data = Buffer(capacity: maxBytes)
 		var flags: Int32 = 0
@@ -58,7 +58,7 @@ public class UDPInternetSocket: InternetSocket {
         return (data: out, sender: clientAddress)
     }
 
-	public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil, flags flagArray: [flags] = []) throws {
+	public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil, flags flagArray: [UDPSocketRecvSendFlags] = []) throws {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let len = data.count
 		var flags: Int32 = 0

--- a/Sources/Sockets/UDP/UDPSocket.swift
+++ b/Sources/Sockets/UDP/UDPSocket.swift
@@ -28,10 +28,11 @@ public class UDPInternetSocket: InternetSocket {
         try? self.close()
     }
 
-    public func recvfrom(maxBytes: Int = BufferCapacity) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
+	public func recvfrom(maxBytes: Int = BufferCapacity, flags flagArray: [flags] = []) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let data = Buffer(capacity: maxBytes)
-        let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
+		var flags: Int32 = 0
+		flagArray.forEach { flags |= $0.toCType() }
 
         var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
         let addr = UnsafeMutablePointer<sockaddr_storage>.allocate(capacity: 1)
@@ -57,10 +58,11 @@ public class UDPInternetSocket: InternetSocket {
         return (data: out, sender: clientAddress)
     }
 
-    public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil) throws {
+	public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil, flags flagArray: [flags] = []) throws {
         if isClosed { throw SocketsError(.socketIsClosed) }
         let len = data.count
-        let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
+		var flags: Int32 = 0
+		flagArray.forEach { flags |= $0.toCType() }
         let destination = address ?? self.address
 
         let sentLen = libc.sendto(


### PR DESCRIPTION
Enables setting the flags for udp send and recv with a swift enum.
Im not quite happy with the naming of said enum: `UDPSocketRecvSendFlags` Any suggestions?