### PR TITLE
Fix #142

### DIFF
--- a/Sources/Transport/Streams/ReadableStream.swift
+++ b/Sources/Transport/Streams/ReadableStream.swift
@@ -38,10 +38,10 @@ extension ReadableStream {
     /// Reads all bytes from the stream using
     /// a chunk size.
     public func readAll(chunkSize: Int = 512) throws -> Bytes {
-        var lastSize = 0
+        var lastSize = chunkSize
         var bytes: Bytes = []
 
-        while lastSize < chunkSize {
+        while lastSize >= chunkSize {
             let chunk = try read(max: chunkSize)
             bytes += chunk
             lastSize = chunk.count


### PR DESCRIPTION
Fixed the wrong readAll() implementation for ReadableStream. See https://github.com/vapor/sockets/issues/142 for details.

@tanner0101 If you want me to add some tests, I will do it in another commit.