### PR TITLE
Throw better errors for closed sockets

### DIFF
--- a/Sources/Sockets/TCP/TCPReadableSocket.swift
+++ b/Sources/Sockets/TCP/TCPReadableSocket.swift
@@ -4,10 +4,6 @@ public protocol TCPReadableSocket: TCPSocket, ReadableStream {}
 
 extension TCPReadableSocket {
     public func read(max: Int, into buffer: inout Bytes) throws -> Int {
-        guard !isClosed else {
-            throw SocketsError(.socketIsClosed)
-        }
-        
         let receivedBytes = libc.read(descriptor.raw, &buffer, max)
 
         guard receivedBytes != -1 else {
@@ -24,6 +20,13 @@ extension TCPReadableSocket {
             case EAGAIN:
                 // timeout reached (linux)
                 return 0
+            case EBADF:
+                // socket is (probably) already closed
+                if isClosed {
+                    throw SocketsError(.socketIsClosed)
+                } else {
+                    throw SocketsError(.readFailed)
+                }
             default:
                 throw SocketsError(.readFailed)
             }

--- a/Sources/Sockets/TCP/TCPReadableSocket.swift
+++ b/Sources/Sockets/TCP/TCPReadableSocket.swift
@@ -4,6 +4,10 @@ public protocol TCPReadableSocket: TCPSocket, ReadableStream {}
 
 extension TCPReadableSocket {
     public func read(max: Int, into buffer: inout Bytes) throws -> Int {
+        guard !isClosed else {
+            throw SocketsError(.socketIsClosed)
+        }
+        
         let receivedBytes = libc.read(descriptor.raw, &buffer, max)
 
         guard receivedBytes != -1 else {

--- a/Sources/Sockets/TCP/TCPWriteableSocket.swift
+++ b/Sources/Sockets/TCP/TCPWriteableSocket.swift
@@ -4,6 +4,10 @@ public protocol TCPWriteableSocket: TCPSocket, WriteableStream { }
 
 extension TCPWriteableSocket {
     public func write(max: Int, from buffer: Bytes) throws -> Int {
+        guard !isClosed else {
+            throw SocketsError(.socketIsClosed)
+        }
+        
         let bytesWritten = libc.send(descriptor.raw, buffer, max, 0)
         
         guard bytesWritten != -1 else {


### PR DESCRIPTION
Avoids syscall overhead as a bonus