### PR TITLE
tcp source/sink

### DIFF
--- a/Sources/TCP/Socket/TCPSocketStatus.swift
+++ b/Sources/TCP/Socket/TCPSocketStatus.swift
@@ -1,0 +1,15 @@
+/// Returned by calls to `Socket.read`
+public enum TCPSocketStatus {
+    /// The socket read normally.
+    /// Note: count == 0 indicates the socket closed.
+    case success(count: Int)
+    /// The internal socket buffer is empty,
+    /// this call would have blocked had this
+    /// socket not been set to non-blocking mode.
+    ///
+    /// Use an event loop to notify you when this socket
+    /// is ready to be read from again.
+    ///
+    /// Note: this is not an error.
+    case wouldBlock
+}

--- a/Sources/TCP/Streams/TCPSocketSink.swift
+++ b/Sources/TCP/Streams/TCPSocketSink.swift
@@ -1,0 +1,165 @@
+import Async
+import Dispatch
+import Foundation
+
+private let maxExcessSignalCount: Int = 2
+
+/// Data stream wrapper for a dispatch socket.
+public final class TCPSocketSink: Async.InputStream {
+    /// See InputStream.Input
+    public typealias Input = UnsafeBufferPointer<UInt8>
+
+    /// The client stream's underlying socket.
+    public var socket: TCPSocket
+
+    /// Data being fed into the client stream is stored here.
+    private var inputBuffer: UnsafeBufferPointer<UInt8>?
+
+    /// Stores write event source.
+    private var writeSource: EventSource?
+
+    /// A strong reference to the current eventloop
+    private var eventLoop: EventLoop
+
+    /// True if this sink has been closed
+    private var isClosed: Bool
+
+    /// Currently waiting done callback
+    private var currentReadyPromise: Promise<Void>?
+
+    /// If true, the read source has been suspended
+    private var sourceIsSuspended: Bool
+
+    /// The current number of signals received while downstream was not ready
+    /// since it was last ready
+    private var excessSignalCount: Int
+
+    /// Creates a new `SocketSink`
+    internal init(socket: TCPSocket, on worker: Worker) {
+        self.socket = socket
+        self.eventLoop = worker.eventLoop
+        self.inputBuffer = nil
+        self.isClosed = false
+        self.sourceIsSuspended = true
+        self.excessSignalCount = 0
+        let writeSource = self.eventLoop.onWritable(descriptor: socket.descriptor, writeSourceSignal)
+        self.writeSource = writeSource
+    }
+
+    /// See InputStream.input
+    public func input(_ event: InputEvent<UnsafeBufferPointer<UInt8>>) {
+        // update variables
+        switch event {
+        case .next(let input, let ready):
+            guard inputBuffer == nil else {
+                fatalError("SocketSink upstream is illegally overproducing input buffers.")
+            }
+            inputBuffer = input
+            writeData(ready: ready)
+        case .close:
+            close()
+        case .error(let e):
+            close()
+            fatalError("\(e)")
+        }
+    }
+
+    /// Cancels reading
+    public func close() {
+        guard !isClosed else {
+            return
+        }
+        guard let writeSource = self.writeSource else {
+            fatalError("SocketSink writeSource illegally nil during close.")
+        }
+        writeSource.cancel()
+        socket.close()
+        self.writeSource = nil
+        isClosed = true
+    }
+
+    /// Writes the buffered data to the socket.
+    private func writeData(ready: Promise<Void>) {
+        do {
+            guard let buffer = self.inputBuffer else {
+                fatalError("Unexpected nil SocketSink inputBuffer during writeData")
+            }
+
+            let write = try socket.write(from: buffer)
+            switch write {
+            case .success(let count):
+                switch count {
+                case buffer.count:
+                    self.inputBuffer = nil
+                    ready.complete()
+                default:
+                    inputBuffer = UnsafeBufferPointer<UInt8>(
+                        start: buffer.baseAddress?.advanced(by: count),
+                        count: buffer.count - count
+                    )
+                    writeData(ready: ready)
+                }
+            case .wouldBlock:
+                resumeIfSuspended()
+                guard currentReadyPromise == nil else {
+                    fatalError("SocketSink currentReadyPromise illegally not nil during wouldBlock.")
+                }
+                currentReadyPromise = ready
+            }
+        } catch {
+            self.error(error)
+            ready.complete()
+        }
+    }
+
+    /// Called when the write source signals.
+    private func writeSourceSignal(isCancelled: Bool) {
+        guard !isCancelled else {
+            // source is cancelled, we will never receive signals again
+            close()
+            return
+        }
+
+        guard inputBuffer != nil else {
+            // no data ready for socket yet
+            excessSignalCount = excessSignalCount &+ 1
+            if excessSignalCount >= maxExcessSignalCount {
+                guard let writeSource = self.writeSource else {
+                    fatalError("SocketSink writeSource illegally nil during signal.")
+                }
+                writeSource.suspend()
+                sourceIsSuspended = true
+            }
+            return
+        }
+
+        guard let ready = currentReadyPromise else {
+            fatalError("SocketSink currentReadyPromise illegaly nil during signal.")
+        }
+        currentReadyPromise = nil
+        writeData(ready: ready)
+    }
+
+    private func resumeIfSuspended() {
+        guard sourceIsSuspended else {
+            return
+        }
+
+        guard let writeSource = self.writeSource else {
+            fatalError("SocketSink writeSource illegally nil during resumeIfSuspended.")
+        }
+        sourceIsSuspended = false
+        // start listening for ready notifications
+        writeSource.resume()
+    }
+}
+
+/// MARK: Create
+
+extension TCPSocket {
+    /// Creates a data stream for this socket on the supplied event loop.
+    public func sink(on eventLoop: Worker) -> TCPSocketSink {
+        return .init(socket: self, on: eventLoop)
+    }
+}
+

--- a/Sources/TCP/Streams/TCPSocketSource.swift
+++ b/Sources/TCP/Streams/TCPSocketSource.swift
@@ -1,0 +1,184 @@
+import Async
+import Dispatch
+import Foundation
+
+private let maxExcessSignalCount: Int = 2
+
+/// Data stream wrapper for a dispatch socket.
+public final class TCPSocketSource: Async.OutputStream {
+    /// See OutputStream.Output
+    public typealias Output = UnsafeBufferPointer<UInt8>
+
+    /// The client stream's underlying socket.
+    public var socket: TCPSocket
+
+    /// Bytes from the socket are read into this buffer.
+    /// Views into this buffer supplied to output streams.
+    private var buffer: UnsafeMutableBufferPointer<UInt8>
+
+    /// Stores read event source.
+    private var readSource: EventSource?
+
+    /// Use a basic stream to easily implement our output stream.
+    private var downstream: AnyInputStream<UnsafeBufferPointer<UInt8>>?
+
+    /// A strong reference to the current eventloop
+    private var eventLoop: EventLoop
+
+    /// True if this source has been closed
+    private var isClosed: Bool
+
+    /// If true, downstream is ready for data.
+    private var downstreamIsReady: Bool
+
+    /// If true, the read source has been suspended
+    private var sourceIsSuspended: Bool
+
+    /// The current number of signals received while downstream was not ready
+    /// since it was last ready
+    private var excessSignalCount: Int
+
+    /// If true, the source has received EOF signal.
+    /// Event source should no longer be resumed. Keep reading until there is 0 return.
+    private var cancelIsPending: Bool
+
+    /// Creates a new `SocketSource`
+    internal init(socket: TCPSocket, on worker: Worker, bufferSize: Int) {
+        self.socket = socket
+        self.eventLoop = worker.eventLoop
+        self.isClosed = false
+        self.buffer = .init(start: .allocate(capacity: bufferSize), count: bufferSize)
+        self.downstreamIsReady = true
+        self.sourceIsSuspended = true
+        self.cancelIsPending = false
+        self.excessSignalCount = 0
+        let readSource = self.eventLoop.onReadable(descriptor: socket.descriptor, readSourceSignal)
+        self.readSource = readSource
+    }
+
+    /// See OutputStream.output
+    public func output<S>(to inputStream: S) where S: Async.InputStream, S.Input == UnsafeBufferPointer<UInt8> {
+        downstream = AnyInputStream(inputStream)
+        readData()
+    }
+
+    /// Cancels reading
+    public func close() {
+        guard !isClosed else {
+            return
+        }
+        guard let readSource = self.readSource else {
+            fatalError("SocketSource readSource illegally nil during close.")
+        }
+        readSource.cancel()
+        socket.close()
+        downstream?.close()
+        self.readSource = nil
+        downstream = nil
+        isClosed = true
+    }
+
+    /// Reads data and outputs to the output stream
+    /// important: the socket _must_ be ready to read data
+    /// as indicated by a read source.
+    private func readData() {
+        guard let downstream = self.downstream else {
+            fatalError("Unexpected nil downstream on SocketSource during readData.")
+        }
+        do {
+            let read = try socket.read(into: buffer)
+            switch read {
+            case .success(let count):
+                guard count > 0 else {
+                    close()
+                    return
+                }
+
+                let view = UnsafeBufferPointer<UInt8>(start: buffer.baseAddress, count: count)
+                downstreamIsReady = false
+                let promise = Promise(Void.self)
+                downstream.input(.next(view, promise))
+                promise.future.addAwaiter { result in
+                    switch result {
+                    case .error(let e): downstream.error(e)
+                    case .expectation:
+                        if self.cancelIsPending {
+                            // don't both resuming source, it's cancelled.
+                            // continue to read until 0
+                            self.readData()
+                        } else {
+                            // not cancelled yet, just resume the source instead
+                            // of trying to read again to relieve stack pressure
+                            self.downstreamIsReady = true
+                            self.resumeIfSuspended()
+                        }
+                    }
+                }
+            case .wouldBlock:
+                resumeIfSuspended()
+            }
+        } catch {
+            // any errors that occur here cannot be thrown,
+            // so send them to stream error catcher.
+            downstream.error(error)
+        }
+    }
+
+    /// Called when the read source signals.
+    private func readSourceSignal(isCancelled: Bool) {
+        guard !isCancelled else {
+            // source is cancelled, we will never receive signals again
+            cancelIsPending = true
+            if downstreamIsReady {
+                readData()
+            }
+            return
+        }
+
+        guard downstreamIsReady else {
+            // downstream is not ready for data yet
+            excessSignalCount = excessSignalCount &+ 1
+            if excessSignalCount >= maxExcessSignalCount {
+                guard let readSource = self.readSource else {
+                    fatalError("SocketSource readSource illegally nil during signal.")
+                }
+                readSource.suspend()
+                sourceIsSuspended = true
+            }
+            return
+        }
+
+        // downstream ready, reset exces count
+        excessSignalCount = 0
+        readData()
+    }
+
+    /// Resumes the readSource if it was currently suspended.
+    private func resumeIfSuspended() {
+        guard sourceIsSuspended else {
+            return
+        }
+
+        guard let readSource = self.readSource else {
+            fatalError("SocketSource readSource illegally nil on resumeIfSuspended.")
+        }
+        sourceIsSuspended = false
+        readSource.resume()
+    }
+
+    /// Deallocated the pointer buffer
+    deinit {
+        buffer.baseAddress?.deallocate()
+    }
+}
+
+/// MARK: Create
+
+extension TCPSocket {
+    /// Creates a data stream for this socket on the supplied event loop.
+    public func source(on eventLoop: Worker, bufferSize: Int = 4096) -> TCPSocketSource {
+        return .init(socket: self, on: eventLoop, bufferSize: bufferSize)
+    }
+}
+
+

--- a/Sources/TCP/Streams/TCPSocketStream.swift
+++ b/Sources/TCP/Streams/TCPSocketStream.swift
@@ -1,0 +1,39 @@
+import Async
+
+/// An async `UnsafeBufferPointer<UInt8>` stream wrapper for `TCPSocket`.
+public final class TCPSocketStream: Stream {
+    /// See `InputStream.Input`
+    public typealias Input = UnsafeBufferPointer<UInt8>
+
+    /// See `OutputStream.Output`
+    public typealias Output = UnsafeBufferPointer<UInt8>
+
+    /// Internal socket source stream.
+    internal let source: TCPSocketSource
+
+    /// Internal socket sink stream.
+    internal let sink: TCPSocketSink
+
+    /// Internal stream init. Use socket convenience method.
+    internal init(socket: TCPSocket, bufferSize: Int, on worker: Worker) {
+        self.source = socket.source(on: worker, bufferSize: bufferSize)
+        self.sink = socket.sink(on: worker)
+    }
+
+    /// See `InputStream.input(_:)`
+    public func input(_ event: InputEvent<UnsafeBufferPointer<UInt8>>) {
+        sink.input(event)
+    }
+
+    /// See `OutputStream.input(_:)`
+    public func output<S>(to inputStream: S) where S : InputStream, TCPSocketStream.Output == S.Input {
+        source.output(to: inputStream)
+    }
+}
+
+extension TCPSocket {
+    /// Create a `TCPSocketStream` for this socket.
+    public func stream(bufferSize: Int = 4096, on worker: Worker) {
+        self.stream(bufferSize: bufferSize, on: worker)
+    }
+}

--- a/Sources/TCP/Utilties/TCPSocket+Data.swift
+++ b/Sources/TCP/Utilties/TCPSocket+Data.swift
@@ -4,7 +4,7 @@ import Foundation
 
 extension TCPSocket {
     /// Copies bytes into a buffer and writes them to the socket.
-    public func write(_ data: Data) throws -> SocketWriteStatus {
+    public func write(_ data: Data) throws -> TCPSocketStatus {
         return try data.withByteBuffer { buffer in
             return try write(from: buffer)
         }
@@ -14,13 +14,13 @@ extension TCPSocket {
     public func read(max: Int) throws -> Data {
         var data = Data(repeating: 0, count: max)
 
-        let read = try data.withUnsafeMutableBytes { (pointer: MutableBytesPointer) -> SocketReadStatus in
+        let read = try data.withUnsafeMutableBytes { (pointer: MutableBytesPointer) -> TCPSocketStatus in
             let buffer = MutableByteBuffer(start: pointer, count: max)
             return try self.read(into: buffer)
         }
 
         switch read {
-        case .read(let count): data.removeLast(data.count &- count)
+        case .success(let count): data.removeLast(data.count &- count)
         case .wouldBlock: fatalError()
         }
 


### PR DESCRIPTION
Moves `Async.SocketSource/Sink` here and prefixes with `TCP`. This will allow for better testing and also allow for TLS source/sink to diverge for different requirements. 