### PR TITLE
make reuse addr option false

### DIFF
--- a/Sources/TCP/Socket/TCPSocket.swift
+++ b/Sources/TCP/Socket/TCPSocket.swift
@@ -33,7 +33,7 @@ public final class TCPSocket {
     /// Creates a new TCP socket
     public convenience init(
         isNonBlocking: Bool = true,
-        shouldReuseAddress: Bool = true
+        shouldReuseAddress: Bool = false
     ) throws {
         let sockfd = socket(AF_INET, SOCK_STREAM, 0)
         guard sockfd > 0 else {


### PR DESCRIPTION
Prompted by reports of bugs where Vapor instances failing to terminate continuing to live on and interfere with development.