### PR TITLE
Is closed fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async.git", "1.0.0-beta.1"..<"1.0.0-beta.2"),
 
         // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", "3.0.0-beta.1"..<"3.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/core.git", "3.0.0-beta.2"..<"3.0.0-beta.3"),
     ],
     targets: [
         .target(name: "TCP", dependencies: ["Async", "Bits", "COperatingSystem", "Debugging"]),

--- a/Sources/TCP/Socket/TCPSocket.swift
+++ b/Sources/TCP/Socket/TCPSocket.swift
@@ -17,6 +17,11 @@ public final class TCPSocket {
     /// True if the socket should re-use addresses
     public let shouldReuseAddress: Bool
 
+    /// True if the socket has been closed.
+    public var isClosed: Bool {
+        return descriptor < 0
+    }
+
     /// Creates a TCP socket around an existing descriptor
     public init(
         established: Int32,
@@ -86,6 +91,9 @@ public final class TCPSocket {
     /// Read data from the socket into the supplied buffer.
     /// Returns the amount of bytes actually read.
     public func read(into buffer: MutableByteBuffer) throws -> TCPSocketStatus {
+        guard !isClosed else {
+            throw TCPError(identifier: "read", reason: "Socket is closed.")
+        }
         let receivedBytes = COperatingSystem.read(descriptor, buffer.baseAddress!, buffer.count)
 
         guard receivedBytes != -1 else {
@@ -121,6 +129,10 @@ public final class TCPSocket {
 
     /// Writes all data from the pointer's position with the length specified to this socket.
     public func write(from buffer: ByteBuffer) throws -> TCPSocketStatus {
+        guard !isClosed else {
+            throw TCPError(identifier: "write", reason: "Socket is closed.")
+        }
+
         guard let pointer = buffer.baseAddress else {
             return .success(count: 0)
         }

--- a/Sources/TCP/Streams/TCPSocketSink.swift
+++ b/Sources/TCP/Streams/TCPSocketSink.swift
@@ -97,6 +97,11 @@ public final class TCPSocketSink: Async.InputStream {
     /// Writes the buffered data to the socket.
     private func writeData(ready: Promise<Void>) {
         DEBUG("TCPSocketSink.writeData(\(ready))")
+        guard !socket.isClosed else {
+            close()
+            return
+        }
+
         do {
             guard let buffer = self.inputBuffer else {
                 ERROR("Unexpected nil SocketSink inputBuffer during writeData")

--- a/Sources/TCP/Streams/TCPSocketSource.swift
+++ b/Sources/TCP/Streams/TCPSocketSource.swift
@@ -88,6 +88,11 @@ public final class TCPSocketSource: Async.OutputStream {
     /// as indicated by a read source.
     private func readData() {
         DEBUG("TCPSocketSource.readData()")
+        guard !socket.isClosed else {
+            close()
+            return
+        }
+        
         guard let downstream = self.downstream else {
             ERROR("Unexpected nil downstream on SocketSource during readData.")
             return

--- a/Sources/TCP/Utilties/TCPError.swift
+++ b/Sources/TCP/Utilties/TCPError.swift
@@ -2,7 +2,7 @@ import Debugging
 import COperatingSystem
 
 /// Errors that can be thrown while working with TCP sockets.
-public struct TCPError: Traceable, Debuggable, Helpable, Swift.Error, Encodable {
+public struct TCPError: Debuggable {
     public static let readableName = "TCP Error"
     public let identifier: String
     public var reason: String


### PR DESCRIPTION
- [x] adds `socket.isClosed` property (simply checks that descriptor is valid)
- [x] checks if socket is closed on read/write calls to deliver more meaningful error
- [x] checks if socket is closed in source/sink and closes the stream